### PR TITLE
pluck method throws exception when result of conditions is empty

### DIFF
--- a/lib/fresh_connection/extend/ar_relation.rb
+++ b/lib/fresh_connection/extend/ar_relation.rb
@@ -48,6 +48,8 @@ module FreshConnection
             klass.connection.select_all(select(column_name).arel, nil)
           end
 
+          return result if result.nil? || result.empty?
+
           last_columns = result.last.keys.last
 
           result.map do |attributes|

--- a/spec/unit/fresh_connection_spec.rb
+++ b/spec/unit/fresh_connection_spec.rb
@@ -42,6 +42,10 @@ describe FreshConnection do
     it "pluck is access to slave1" do
       expect(User.pluck(:name).first).to be_include("slave")
     end
+
+    it "pluck returns empty array when result of condition is empty" do
+      expect(User.limit(0).pluck(:name)).to be_empty
+    end
   end
 
   context "access to master" do


### PR DESCRIPTION
For example

``` ruby
User.limit(1).pluck(:name) #=> ["tsukasa"]
User.limit(0).pluck(:name) #=>  NoMethodError: undefined method `keys' for nil:NilClass
```

result must be empty array.
