### PR TITLE
aks/sync query cache changes

### DIFF
--- a/fresh_connection.gemspec
+++ b/fresh_connection.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "benchmark-ips"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/lib/fresh_connection/abstract_connection_manager.rb
+++ b/lib/fresh_connection/abstract_connection_manager.rb
@@ -12,7 +12,7 @@ module FreshConnection
       end
     end
 
-    attr_reader :replica_group
+    attr_reader   :replica_group
 
     def initialize(replica_group = "replica")
       replica_group = "replica" if replica_group.to_s == "slave"

--- a/lib/fresh_connection/connection_factory.rb
+++ b/lib/fresh_connection/connection_factory.rb
@@ -11,8 +11,10 @@ module FreshConnection
       @spec = nil
     end
 
-    def new_connection
-      ActiveRecord::Base.__send__(adapter_method, spec)
+    def new_connection(pool = nil)
+      ActiveRecord::Base.__send__(adapter_method, spec).tap do |conn|
+        conn.connection_pool = pool
+      end
     end
 
     private

--- a/lib/fresh_connection/connection_manager.rb
+++ b/lib/fresh_connection/connection_manager.rb
@@ -1,9 +1,13 @@
+require 'active_record'
 require 'concurrent'
 require 'fresh_connection/abstract_connection_manager'
 require 'fresh_connection/connection_factory'
 
 module FreshConnection
   class ConnectionManager < AbstractConnectionManager
+
+    include ::ActiveRecord::ConnectionAdapters::QueryCache::ConnectionPoolConfiguration
+
     def initialize(*args)
       super
       @connections = Concurrent::Map.new
@@ -11,21 +15,39 @@ module FreshConnection
 
     def replica_connection
       @connections.fetch_or_store(current_thread_id) do |_|
-        connection_factory.new_connection
+        connection_factory.new_connection(self)
       end
     end
 
     def put_aside!
-      conn = @connections.delete(current_thread_id)
-      return unless conn
-      conn && conn.disconnect! rescue nil
+      if (conn = @connections.delete(current_thread_id))
+        conn.disconnect! rescue nil
+      end
     end
 
     def clear_all_connections!
-      @connections.each_value do |conn|
+      for_all_connections do |conn|
         conn.disconnect! rescue nil
       end
       @connections.clear
+    end
+
+    def clear_replica_query_caches!
+      for_all_connections do |conn|
+        conn.clear_query_cache
+      end
+    end
+
+    def enable_query_cache!
+      for_all_connections do |conn|
+        conn.enable_query_cache!
+      end
+    end
+
+    def disable_query_cache!
+      for_all_connections do |conn|
+        conn.disable_query_cache!
+      end
     end
 
     def recovery?
@@ -35,6 +57,12 @@ module FreshConnection
     end
 
     private
+
+    def for_all_connections
+      @connections.each_value do |connection|
+        yield(connection)
+      end
+    end
 
     def connection_factory
       @connection_factory ||= ConnectionFactory.new(@replica_group)

--- a/lib/fresh_connection/extend/ar_abstract_adapter.rb
+++ b/lib/fresh_connection/extend/ar_abstract_adapter.rb
@@ -1,8 +1,16 @@
+require 'pry-byebug'
+
 module FreshConnection
   module Extend
     module ArAbstractAdapter
       def self.prepended(base)
-        base.send :attr_writer, :replica_group
+        base.send :attr_accessor, :replica_group
+        base.send :attr_accessor, :connection_pool
+      end
+
+      def initialize(connection, logger = nil, config = {})
+        super
+        @connection_pool = nil
       end
 
       def log(*args)
@@ -12,9 +20,13 @@ module FreshConnection
 
       # This is normally called only on master connections, so we need
       # to clear the replica connection caches, too.  But, don't recurse.
-      #def clear_query_cache
-      #  replica_connection.clear_query_cache unless replica_group
-      #end
+      def clear_query_cache
+        if FreshConnection::ReplicaConnectionHandler.replica_query_cache_sync
+          ActiveRecord::Base.clear_all_query_caches! unless replica_group
+        end
+        super
+      end
+
     end
   end
 end

--- a/lib/fresh_connection/extend/ar_abstract_adapter.rb
+++ b/lib/fresh_connection/extend/ar_abstract_adapter.rb
@@ -9,6 +9,12 @@ module FreshConnection
         args[1] = "[#{@replica_group}] #{args[1]}" if defined?(@replica_group)
         super
       end
+
+      # This is normally called only on master connections, so we need
+      # to clear the replica connection caches, too.  But, don't recurse.
+      #def clear_query_cache
+      #  replica_connection.clear_query_cache unless replica_group
+      #end
     end
   end
 end

--- a/lib/fresh_connection/extend/ar_base.rb
+++ b/lib/fresh_connection/extend/ar_base.rb
@@ -29,6 +29,10 @@ module FreshConnection
         replica_connection_handler.establish_connection(name, replica_group)
       end
 
+      def master_connection
+        superclass.connection
+      end
+
       def replica_connection
         replica_connection_handler.connection(self)
       end
@@ -51,6 +55,22 @@ module FreshConnection
         )
 
         clear_all_replica_connections!
+      end
+
+      def clear_all_query_caches!
+        replica_connection_handler.clear_all_query_caches!
+      end
+
+      def enable_replica_query_cache_sync!
+        FreshConnection::ReplicaConnectionHandler.enable_query_cache_sync!
+      end
+
+      def disable_replica_query_cache_sync!
+        FreshConnection::ReplicaConnectionHandler.disable_query_cache_sync!
+      end
+
+      def replica_query_cache_sync
+        FreshConnection::ReplicaConnectionHandler.replica_query_cache_sync
       end
 
       def master_db_only!

--- a/lib/fresh_connection/replica_connection_handler.rb
+++ b/lib/fresh_connection/replica_connection_handler.rb
@@ -1,7 +1,19 @@
 require 'concurrent'
 
 module FreshConnection
+
   class ReplicaConnectionHandler
+
+    cattr_accessor :replica_query_cache_sync
+
+    def self.enable_query_cache_sync!
+      @@replica_query_cache_sync = true
+    end
+
+    def self.disable_query_cache_sync!
+      @@replica_query_cache_sync = false
+    end
+
     def initialize
       @replica_group_to_pool = Concurrent::Map.new
       @class_to_pool = Concurrent::Map.new
@@ -23,6 +35,12 @@ module FreshConnection
     def clear_all_connections!
       all_connection_managers do |connection_manager|
         connection_manager.clear_all_connections!
+      end
+    end
+
+    def clear_all_query_caches!
+      all_connection_managers do |connection_manager|
+        connection_manager.clear_replica_query_caches!
       end
     end
 

--- a/lib/fresh_connection/version.rb
+++ b/lib/fresh_connection/version.rb
@@ -1,4 +1,4 @@
 module FreshConnection
-  VERSION = "2.3.0.rc2"
+  VERSION = "2.3.0.rc3"
 end
 

--- a/test/ar_base/ar_abstract_adapter_test.rb
+++ b/test/ar_base/ar_abstract_adapter_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+#require 'pry-byebug'
+
+class AbstractAdapterTest < Minitest::Test
+
+  class Tel < ActiveRecord::Base
+    establish_fresh_connection :fake_replica
+    enable_replica_query_cache_sync!
+
+    belongs_to :user
+  end
+
+  def setup
+    ActiveRecord::Base.connection.clear_query_cache
+  end
+
+  test "cache_query is incorrect after master update with replica cache syncing disabled" do
+
+    Tel.cache do
+
+      Tel.replica_connection.enable_query_cache!
+      Tel.disable_replica_query_cache_sync!
+
+      tel = Tel.find(1)
+      assert_match(/master/ , tel.number)
+      rconn = Tel.replica_connection
+      mconn = Tel.master_connection
+
+      refute rconn.query_cache.empty?
+      assert mconn.query_cache.empty?
+
+      orig_number = tel.number
+      tel.number = tel.number.sub(/master/,'fake_replica')
+      tel.save!
+      assert mconn.query_cache.empty?
+      refute rconn.query_cache.empty?       # the replica cache should still have some contents after an update
+
+      tel2 = Tel.find(1)
+      refute_equal tel2.number, tel.number  # the replica cache contents should be stale
+
+      tel.number = orig_number
+      tel.save!
+    end
+
+  end
+
+  test "cache_query is correct after master update with replica cache syncing enabled" do
+
+    Tel.cache do
+
+      Tel.replica_connection.enable_query_cache!
+      Tel.enable_replica_query_cache_sync!
+
+      tel = Tel.find(1)
+      assert_match(/master/ , tel.number)
+      rconn = Tel.replica_connection
+      mconn = Tel.master_connection
+
+      refute rconn.query_cache.empty?     # the replica cache should have some contents
+      assert mconn.query_cache.empty?     # the master connection cache is always empty
+
+      orig_number = tel.number
+      tel.number = tel.number.sub(/master/,'fake_replica')
+      tel.save!
+
+      tel2 = Tel.find(1)
+      assert_equal tel2.number, tel.number  # the replica should have pulled fresh, correct data
+
+      tel.number = orig_number
+      tel.save!
+    end
+
+  end
+
+end
+

--- a/test/config/database_mysql2.yml
+++ b/test/config/database_mysql2.yml
@@ -12,3 +12,5 @@ test:
   replica2:
     database: fresh_connection_test_replica2
 
+  fake_replica:
+    database: fresh_connection_test_master

--- a/test/config/database_postgresql.yml
+++ b/test/config/database_postgresql.yml
@@ -10,3 +10,5 @@ test:
   replica2:
     database: fresh_connection_test_replica2
 
+  fake_replica:
+    database: fresh_connection_test_master

--- a/test/config/mysql_schema.sql
+++ b/test/config/mysql_schema.sql
@@ -21,6 +21,8 @@
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `fresh_connection_test_master` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
+SYSTEM echo "Loading master data set"
+
 USE `fresh_connection_test_master`;
 
 --
@@ -109,6 +111,8 @@ UNLOCK TABLES;
 --
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `fresh_connection_test_replica1` /*!40100 DEFAULT CHARACTER SET utf8 */;
+
+SYSTEM echo "Loading replica1 data set"
 
 USE `fresh_connection_test_replica1`;
 
@@ -200,6 +204,7 @@ UNLOCK TABLES;
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `fresh_connection_test_replica2` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
+SYSTEM echo "Loading replica2 data set"
 USE `fresh_connection_test_replica2`;
 
 --

--- a/test/config/psql_test_master.sql
+++ b/test/config/psql_test_master.sql
@@ -1,85 +1,11 @@
-SET statement_timeout = 0;
-SET lock_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
-SET row_security = off;
+-- create the master data set
+\echo Setting up master data set
 
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-SET search_path = public, pg_catalog;
-
-SET default_tablespace = '';
-
-SET default_with_oids = false;
-
-CREATE TABLE addresses (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    prefecture character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE addresses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
-
-CREATE TABLE tels (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    number character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE tels_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE tels_id_seq OWNED BY tels.id;
-
-CREATE TABLE users (
-    id integer NOT NULL,
-    name character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE users_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE users_id_seq OWNER TO tsukasa;
-
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
-
-ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
-
-ALTER TABLE ONLY tels ALTER COLUMN id SET DEFAULT nextval('tels_id_seq'::regclass);
-
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+\ir psql_test_schema_setup1.sql
 
 COPY addresses (id, user_id, prefecture, created_at, updated_at) FROM stdin;
 1	1	Tokyo (master)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
-
-SELECT pg_catalog.setval('addresses_id_seq', 1, false);
 
 COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 1	1	03-1111-1111 (master)	2014-04-10 07:24:16	2014-04-10 07:24:16
@@ -87,25 +13,9 @@ COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 3	1	03-1111-1113 (master)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('tels_id_seq', 1, false);
-
 COPY users (id, name, created_at, updated_at) FROM stdin;
 1	Tsukasa (master)	2014-04-10 07:24:16	2014-04-10 07:24:16
 2	Other	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('users_id_seq', 1, false);
-
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY tels
-    ADD CONSTRAINT tels_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON SCHEMA public FROM tsukasa;
-GRANT ALL ON SCHEMA public TO tsukasa;
-GRANT ALL ON SCHEMA public TO PUBLIC;
+\ir psql_test_schema_setup2.sql

--- a/test/config/psql_test_replica1.sql
+++ b/test/config/psql_test_replica1.sql
@@ -1,85 +1,11 @@
-SET statement_timeout = 0;
-SET lock_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
-SET row_security = off;
+-- create replica1 data set
+\echo Setting up replica1 data set
 
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-SET search_path = public, pg_catalog;
-
-SET default_tablespace = '';
-
-SET default_with_oids = false;
-
-CREATE TABLE addresses (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    prefecture character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE addresses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
-
-CREATE TABLE tels (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    number character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE tels_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE tels_id_seq OWNED BY tels.id;
-
-CREATE TABLE users (
-    id integer NOT NULL,
-    name character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE users_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE users_id_seq OWNER TO tsukasa;
-
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
-
-ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
-
-ALTER TABLE ONLY tels ALTER COLUMN id SET DEFAULT nextval('tels_id_seq'::regclass);
-
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+\ir psql_test_schema_setup1.sql
 
 COPY addresses (id, user_id, prefecture, created_at, updated_at) FROM stdin;
 1	1	Tokyo (replica1)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
-
-SELECT pg_catalog.setval('addresses_id_seq', 1, false);
 
 COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 1	1	03-1111-1111 (replica1)	2014-04-10 07:24:16	2014-04-10 07:24:16
@@ -87,26 +13,11 @@ COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 3	1	03-1111-1113 (replica1)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('tels_id_seq', 1, false);
-
 COPY users (id, name, created_at, updated_at) FROM stdin;
 1	Tsukasa (replica1)	2014-04-10 07:24:16	2014-04-10 07:24:16
 2	Other	2014-04-10 07:24:16	2014-04-10 07:24:16
 3	Other	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('users_id_seq', 1, false);
+\ir psql_test_schema_setup2.sql
 
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY tels
-    ADD CONSTRAINT tels_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON SCHEMA public FROM tsukasa;
-GRANT ALL ON SCHEMA public TO tsukasa;
-GRANT ALL ON SCHEMA public TO PUBLIC;

--- a/test/config/psql_test_replica2.sql
+++ b/test/config/psql_test_replica2.sql
@@ -1,85 +1,12 @@
-SET statement_timeout = 0;
-SET lock_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
-SET row_security = off;
+-- setup replica2 data set
 
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+\echo Setting up replica2 data set
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-SET search_path = public, pg_catalog;
-
-SET default_tablespace = '';
-
-SET default_with_oids = false;
-
-CREATE TABLE addresses (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    prefecture character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE addresses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
-
-CREATE TABLE tels (
-    id integer NOT NULL,
-    user_id integer DEFAULT 0 NOT NULL,
-    number character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE tels_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE tels_id_seq OWNED BY tels.id;
-
-CREATE TABLE users (
-    id integer NOT NULL,
-    name character varying DEFAULT ''::character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-CREATE SEQUENCE users_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE users_id_seq OWNER TO tsukasa;
-
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
-
-ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
-
-ALTER TABLE ONLY tels ALTER COLUMN id SET DEFAULT nextval('tels_id_seq'::regclass);
-
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+\ir psql_test_schema_setup1.sql
 
 COPY addresses (id, user_id, prefecture, created_at, updated_at) FROM stdin;
 1	1	Tokyo (replica2)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
-
-SELECT pg_catalog.setval('addresses_id_seq', 1, false);
 
 COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 1	1	03-1111-1111 (replica2)	2014-04-10 07:24:16	2014-04-10 07:24:16
@@ -87,26 +14,10 @@ COPY tels (id, user_id, number, created_at, updated_at) FROM stdin;
 3	1	03-1111-1113 (replica2)	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('tels_id_seq', 1, false);
-
 COPY users (id, name, created_at, updated_at) FROM stdin;
 1	Tsukasa (replica2)	2014-04-10 07:24:16	2014-04-10 07:24:16
 2	Other	2014-04-10 07:24:16	2014-04-10 07:24:16
 3	Other	2014-04-10 07:24:16	2014-04-10 07:24:16
 \.
 
-SELECT pg_catalog.setval('users_id_seq', 1, false);
-
-ALTER TABLE ONLY addresses
-    ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY tels
-    ADD CONSTRAINT tels_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON SCHEMA public FROM tsukasa;
-GRANT ALL ON SCHEMA public TO tsukasa;
-GRANT ALL ON SCHEMA public TO PUBLIC;
+\ir psql_test_schema_setup2.sql

--- a/test/config/psql_test_schema_setup1.sql
+++ b/test/config/psql_test_schema_setup1.sql
@@ -1,0 +1,83 @@
+-- create the schema (part 1)
+
+\set QUIET 1
+\timing off
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+DROP TABLE IF EXISTS addresses CASCADE;
+DROP TABLE IF EXISTS tels      CASCADE;
+DROP TABLE IF EXISTS users     CASCADE;
+
+CREATE TABLE addresses (
+  id integer NOT NULL,
+  user_id integer DEFAULT 0 NOT NULL,
+  prefecture character varying DEFAULT ''::character varying NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  updated_at timestamp without time zone NOT NULL
+);
+
+CREATE SEQUENCE addresses_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
+
+CREATE TABLE tels (
+  id integer NOT NULL,
+  user_id integer DEFAULT 0 NOT NULL,
+  number character varying DEFAULT ''::character varying NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  updated_at timestamp without time zone NOT NULL
+);
+
+CREATE SEQUENCE tels_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+ALTER SEQUENCE tels_id_seq OWNED BY tels.id;
+
+CREATE TABLE users (
+  id integer NOT NULL,
+  name character varying DEFAULT ''::character varying NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  updated_at timestamp without time zone NOT NULL
+);
+
+CREATE SEQUENCE users_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+ALTER SEQUENCE users_id_seq OWNED BY users.id;
+
+ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
+
+ALTER TABLE ONLY tels ALTER COLUMN id SET DEFAULT nextval('tels_id_seq'::regclass);
+
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);

--- a/test/config/psql_test_schema_setup2.sql
+++ b/test/config/psql_test_schema_setup2.sql
@@ -1,0 +1,19 @@
+-- part2 setup of the test schema, post data load
+
+\o /dev/null
+SELECT pg_catalog.setval('addresses_id_seq', 1, false);
+SELECT pg_catalog.setval('tels_id_seq', 1, false);
+SELECT pg_catalog.setval('users_id_seq', 1, false);
+\o
+
+ALTER TABLE ONLY addresses
+  ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY tels
+  ADD CONSTRAINT tels_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY users
+  ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;


### PR DESCRIPTION
This PR adds support for syncing query cache changes from the master connection cache to the replica query caches.

The new test script confirms that a cache syncing problems exists, with `replica_query_cache_sync` disabled, and then confirms that the problem does not occur when `replica_query_cache_sync` is enabled.

The feature is controlled by a class variable `@@replica_query_cache_sync` that is false by default -- in order to maintain backward compatibility and not provide any query cache behavior by default.



