### PR TITLE
Disconnect broken replica server on activerecord >= 6.1

### DIFF
--- a/lib/fresh_connection/access_control.rb
+++ b/lib/fresh_connection/access_control.rb
@@ -62,6 +62,7 @@ module FreshConnection
       def catch_exceptions
         return @catch_exceptions if defined?(@catch_exceptions)
         @catch_exceptions = [ActiveRecord::StatementInvalid]
+        @catch_exceptions << ActiveRecord::ConnectionNotEstablished
         @catch_exceptions << ::Mysql2::Error if defined?(::Mysql2)
 
         if defined?(::PG)

--- a/test/recovery_test.rb
+++ b/test/recovery_test.rb
@@ -48,4 +48,52 @@ class RecoveryTest < Minitest::Test
       end
     end
   end
+
+  test "enable recovery (activerecord >= 6.1)" do
+    count = 0
+    raise_exception = lambda {|*args, &block|
+      if count == 0
+        count += 1
+        raise ActiveRecord::ConnectionNotEstablished, "hoge"
+      end
+    }
+
+    FreshConnection::AccessControl.exception_or_super(:access, raise_exception) do
+      FreshConnection::AccessControl.stub(:recovery?, true) do
+        assert User.take
+      end
+    end
+  end
+
+  test "raise exception when retry over (activerecord >= 6.1)" do
+    raise_exception = lambda {|*args|
+      raise ActiveRecord::ConnectionNotEstablished, "hoge"
+    }
+
+    FreshConnection::AccessControl.stub(:access, raise_exception) do
+      FreshConnection::AccessControl.stub(:recovery?, true) do
+        assert_raises(ActiveRecord::ConnectionNotEstablished) do
+          User.take
+        end
+      end
+    end
+  end
+
+  test "raise exception when conection active (activerecord >= 6.1)" do
+    count = 0
+    raise_exception = lambda {|*args, &block|
+      if count == 0
+        count += 1
+        raise ActiveRecord::ConnectionNotEstablished, "hoge"
+      end
+    }
+
+    FreshConnection::AccessControl.exception_or_super(:access, raise_exception) do
+      FreshConnection::AccessControl.stub(:recovery?, false) do
+        assert_raises(ActiveRecord::ConnectionNotEstablished) do
+          User.take
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
@tsukasaoishi  お久しぶりです！

ref: https://github.com/rails/rails/releases/tag/v6.1.0

> All connection adapters execute now raises
> `ActiveRecord::ConnectionNotEstablished` rather than `ActiveRecord::StatementInvalid` when they encounter a connection error.